### PR TITLE
Correct the save test

### DIFF
--- a/Tests/CacheTests/CacheTests.swift
+++ b/Tests/CacheTests/CacheTests.swift
@@ -238,6 +238,7 @@ final class CacheTestCases: XCTestCase {
         }
 
         // When
+        cache?.layer.save()
         cache = nil
         cache = TestMemoryCache(policies: [], identifier: #function, location: location)
 


### PR DESCRIPTION
### What:
Swift doesn't guarantee the order in which types are destroyed, so had to force a save before reloading the cache to guarantee data was saved before the next load.

### Why:
Test would randomly fail.

### How:
Added a call to save to guarantee data made it to disk before the next test step.

### Testing Notes
Test is still valid because what we want to know is that when we save data it will reload on the next instance.
