### PR TITLE
Updates for Swift 6.0

### DIFF
--- a/Cache.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cache.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "be552bbcd2502ae6b4482df0d4c1d8ef4e5dae7081c7e96fa228793c10612d56",
   "pins" : [
     {
       "identity" : "gauntlet-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krogerco/Gauntlet-iOS.git",
       "state" : {
-        "revision" : "4a4fe12bb927e775112c97686f57c52392d72ae1",
-        "version" : "1.1.0"
+        "revision" : "028896ab3b1ed89b185e890e67cd4635496acb1e",
+        "version" : "2.2.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Cache",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v12)
+        .iOS(.v16),
+        .macOS(.v13)
     ],
     products: [
         .library(
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["Cache"])
     ],
     dependencies: [
-        .package(url: "https://github.com/krogerco/Gauntlet-iOS.git", from: Version(1, 0, 0))
+        .package(url: "https://github.com/krogerco/Gauntlet-iOS.git", from: "2.2.0")
     ],
     targets: [
         .target(name: "Cache"),
@@ -23,7 +23,7 @@ let package = Package(
             name: "CacheTests",
             dependencies: [
                 .byName(name: "Cache"),
-                .product(name: "Gauntlet", package: "Gauntlet-iOS")
+                .product(name: "GauntletLegacy", package: "Gauntlet-iOS")
             ]
         )
     ]

--- a/Sources/Cache/Cache.swift
+++ b/Sources/Cache/Cache.swift
@@ -26,7 +26,7 @@ import Foundation
 typealias EventPublisher = PassthroughSubject<CacheEvent, Never>
 
 /// A memory based cache with configurable policies and optional persistence.
-public final class Cache<Key: CacheKey, Value: Codable> {
+public final class Cache<Key: CacheKey, Value: Codable>: @unchecked Sendable {
     let lock = NSRecursiveLock()
     let layer: MemoryCacheLayer<Key, Value>
     let identifier: String

--- a/Sources/Cache/CacheConfig.swift
+++ b/Sources/Cache/CacheConfig.swift
@@ -23,7 +23,7 @@
 import Combine
 import Foundation
 
-class CacheConfig {
+struct CacheConfig {
     let location: CacheLocation?
     let eventPublisher: EventPublisher
 

--- a/Sources/Cache/CacheEvent.swift
+++ b/Sources/Cache/CacheEvent.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// Cache internal events that might be useful for debugging.
-public enum CacheEvent {
+public enum CacheEvent: Sendable {
     /// Cache was unable to load from the file. Will happen on first launch or if the Value type changes.
     case unableToLoad(URL, Error)
 

--- a/Sources/Cache/CacheKey.swift
+++ b/Sources/Cache/CacheKey.swift
@@ -23,4 +23,4 @@
 import Foundation
 
 /// The key used to look items up in cache objects.
-public typealias CacheKey = Hashable & Codable
+public typealias CacheKey = Hashable & Codable & Sendable

--- a/Sources/Cache/CacheLayer/MemoryCacheLayer.swift
+++ b/Sources/Cache/CacheLayer/MemoryCacheLayer.swift
@@ -28,7 +28,7 @@ import UIKit
 #endif
 
 /// A fully in-memory based cache with persistence.
-final class MemoryCacheLayer<Key: CacheKey, Value: Codable>: CacheLayer {
+final class MemoryCacheLayer<Key: CacheKey, Value: Codable>: CacheLayer, @unchecked Sendable {
     var config = CacheConfig()
     let policies: [CachePolicy]
     var cache: [Key: Item] = [:]
@@ -89,16 +89,16 @@ final class MemoryCacheLayer<Key: CacheKey, Value: Codable>: CacheLayer {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            guard let strongSelf = self else { return }
+            guard let self else { return }
 
-            strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
+            lock.lock(); defer { lock.unlock() }
 
             // Bail if empty.
-            guard !strongSelf.cache.isEmpty else { return }
+            guard !cache.isEmpty else { return }
 
             // Apply a policy that will purge half of the current cache.
-            let purgeAmount = strongSelf.cache.count / 2
-            strongSelf.apply([.maxItemCount(purgeAmount)])
+            let purgeAmount = cache.count / 2
+            apply([.maxItemCount(purgeAmount)])
         }
 #endif
     }

--- a/Sources/Cache/CacheLocation.swift
+++ b/Sources/Cache/CacheLocation.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// Specifies a directory where ``CacheLayer``s are stored.
-public struct CacheLocation {
+public struct CacheLocation: Sendable {
     /// Name of this location.
     public let locationName: String
 

--- a/Sources/Cache/CachePolicy.swift
+++ b/Sources/Cache/CachePolicy.swift
@@ -25,7 +25,7 @@ import Foundation
 /// Policies that may be applied to each cache source.
 /// Generally, you would create a different and more lenient policy for each level of cache source.
 /// Specifying no policies results in caches with unbounded growth.
-public enum CachePolicy {
+public enum CachePolicy: Sendable {
     /// The maximum number of key/values the source should track.
     /// When this count is exceeded, the least recently used values will be purged.
     case maxItemCount(Int)

--- a/Sources/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/Sources/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -160,7 +160,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					6732C75029BBAD7100D13B5C = {
 						CreatedOnToolsVersion = 14.2;
@@ -297,6 +297,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -357,6 +358,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -398,7 +400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kroger.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -426,7 +428,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kroger.DemoApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -434,7 +436,6 @@
 		6732C77929BBAD7200D13B5C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -453,7 +454,6 @@
 		6732C77A29BBAD7200D13B5C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Sources/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/Sources/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/CacheTests/CacheLocationTests.swift
+++ b/Tests/CacheTests/CacheLocationTests.swift
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 @testable import Cache
-import Gauntlet
+import GauntletLegacy
 import XCTest
 
 class CacheLocationTests: XCTestCase {

--- a/Tests/CacheTests/CacheTests.swift
+++ b/Tests/CacheTests/CacheTests.swift
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 @testable import Cache
-import Gauntlet
+import GauntletLegacy
 import XCTest
 
 final class CacheTestCases: XCTestCase {

--- a/Tests/CacheTests/CodableFileTests.swift
+++ b/Tests/CacheTests/CodableFileTests.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Gauntlet
+import GauntletLegacy
 @testable import Cache
 import XCTest
 

--- a/Tests/CacheTests/MemoryCacheLayerTests.swift
+++ b/Tests/CacheTests/MemoryCacheLayerTests.swift
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 @testable import Cache
-import Gauntlet
+import GauntletLegacy
 import XCTest
 
 class MemoryCacheLayerTestCase: XCTestCase {

--- a/Tests/CacheTests/MockCacheLayer.swift
+++ b/Tests/CacheTests/MockCacheLayer.swift
@@ -23,7 +23,7 @@
 @testable import Cache
 import Foundation
 
-extension CacheItem: @retroactive Equatable where Key == String, Value: Equatable {
+extension CacheItem: Equatable where Key == String, Value: Equatable {
     public static func == (lhs: CacheItem<Key, Value>, rhs: CacheItem<Key, Value>) -> Bool {
         lhs.key == rhs.key &&
             lhs.creationDate == rhs.creationDate &&


### PR DESCRIPTION
### What:

Updates for Swift 6.0 and concurrency.

### How:

Updated to Gauntlet 2.2.0.
Changed public types to Sendable.
